### PR TITLE
adding trim() to fix class loading issue

### DIFF
--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -33,7 +33,10 @@ class ReflectionClass extends InternalReflectionClass
      */
     public function __construct($argument, ClassLike $classLikeNode = null)
     {
-        $fullClassName       = is_object($argument) ? get_class($argument) : $argument;
+        // @todo (nocworx) adding trim() to fix class loading issue; undo when fixed upstream
+        // @see https://github.com/goaop/parser-reflection/issues/80
+        // @see https://github.com/goaop/parser-reflection/pull/89
+        $fullClassName       = is_object($argument) ? get_class($argument) : trim($argument, '\\');
         $namespaceParts      = explode('\\', $fullClassName);
         $this->className     = array_pop($namespaceParts);
         // Let's unset original read-only property to have a control over it via __get


### PR DESCRIPTION
adds trim() to fix class loading issue; undo when fixed upstream

see https://github.com/goaop/parser-reflection/issues/80
see https://github.com/goaop/parser-reflection/pull/89